### PR TITLE
Spsh 294 obfuscate secret

### DIFF
--- a/charts/dbildungscloud-iam-keycloak/templates/secret.yaml
+++ b/charts/dbildungscloud-iam-keycloak/templates/secret.yaml
@@ -1,3 +1,15 @@
+{{- $dbiamSecrets := (lookup "v1" "Secret" .Release.Namespace .Values.secrets.name )}}
+{{- if not  $dbiamSecrets }}
+{{- fail (print "No secret in namespace " .Release.Namespace " under " .Values.secrets.name " deployment cannot continue") }}
+{{- end }}
+{{- $adminSecret := index $dbiamSecrets.data "keycloak.adminSecret" }}
+{{- $clientSecret := index $dbiamSecrets.data "keycloak.clientSecret" }}
+{{- if not $adminSecret }}
+{{- fail "Admin secret not set"}}
+{{- end }}
+{{- if not $clientSecret }}
+{{- fail "Client secret not set"}}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5,4 +17,4 @@ metadata:
 type: Opaque
 data:
   realm-spsh.json: |-
-      {{.Files.Get "dev-realm-spsh.json" | b64enc}}
+      {{.Files.Get "dev-realm-spsh.json" | replace "___CLIENT_SECRET___" $clientSecret | replace "___ADMIN_SECRET___" $adminSecret | b64enc}}

--- a/charts/dbildungscloud-iam-keycloak/values.yaml
+++ b/charts/dbildungscloud-iam-keycloak/values.yaml
@@ -1,5 +1,7 @@
 keycloakHostname: "keycloak.dev.spsh.dbildungsplattform.de"
 keycloakPublic: false
+secrets:
+  name: dbildungs-iam-secrets
 image:
   repository: ghcr.io/dbildungsplattform/dbildungs-iam
   tag: ""


### PR DESCRIPTION
# Description

Secrets are now put into the keycloak realm config secret by text replacement from a cluster secret
## Links to Tickets or other PRs

<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->
https://ticketsystem.dbildungscloud.de/browse/SPSH-294


## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [X] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.