### PR TITLE
EW-707  upgraded keycloak to v23.0.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ### Keycloak base image with dbildungs-iam extensions
-FROM quay.io/keycloak/keycloak:21.1.2 AS base
+FROM quay.io/keycloak/keycloak:23.0.4 AS base
 
 # dbildungs-iam specific extensions (providers, themes, etc.)
 #COPY src/conf/ /opt/keycloak/conf/

--- a/charts/dbildungscloud-iam-keycloak/dev-realm-spsh.json
+++ b/charts/dbildungscloud-iam-keycloak/dev-realm-spsh.json
@@ -2209,7 +2209,7 @@
       "cibaInterval": "5",
       "realmReusableOtpCode": "false"
     },
-    "keycloakVersion": "22.0.3",
+    "keycloakVersion": "23.0.4",
     "userManagedAccessAllowed": false,
     "clientProfiles": {
       "profiles": []


### PR DESCRIPTION
# Description
Keycloak was upgraded to version 23.0.4

## Links to Tickets or other PRs
Jira: https://ticketsystem.dbildungscloud.de/browse/EW-707
Release notes of keycloak:
- https://www.keycloak.org/docs/latest/release_notes/#keycloak-23-0-0
- https://www.keycloak.org/2024/01/keycloak-2304-released

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.