### PR TITLE
SPSH-1000: Username-Feld wird beim normalen Login Readonly

### DIFF
--- a/src/themes/schulportal/login/login.ftl
+++ b/src/themes/schulportal/login/login.ftl
@@ -16,13 +16,6 @@
                                 aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
                                 <#if !(login.username?? && login.username != '')>autofocus</#if>
                             />
-                                <script>
-                                    const params = new URLSearchParams(document.location.search);
-                                    const hint = params.get("login_hint");
-                                    if (hint)
-                                        document.getElementById('username').setAttribute('readonly', '')
-                                </script>
-
 
                             <#if messagesPerField.existsError('username','password')>
                                 <span id="input-error" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">

--- a/src/themes/schulportal/login/login.ftl
+++ b/src/themes/schulportal/login/login.ftl
@@ -14,8 +14,14 @@
 
                             <input tabindex="2" id="username" class="${properties.kcInputClass!}" name="username" placeholder="${msg("username")}" value="${(login.username!'')}" type="text" autocomplete="username" data-testid="username-input"
                                 aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
-                                <#if !(login.username?? && login.username != '')>autofocus
-                                <#else> readonly</#if> />
+                                <#if !(login.username?? && login.username != '')>autofocus</#if>
+                            />
+                                <script>
+                                    const params = new URLSearchParams(document.location.search);
+                                    const hint = params.get("login_hint");
+                                    if (hint)
+                                        document.getElementById('username').setAttribute('readonly', '')
+                                </script>
 
 
                             <#if messagesPerField.existsError('username','password')>


### PR DESCRIPTION
# Description

## Links to Tickets or other PRs

[Ticket](https://ticketsystem.dbildungscloud.de/browse/SPSH-1000)

## Notes

Entering the wrong username reloads the page and prefills the username field. The current template logic will then make the input readonly, because it assumes we are in the flow to change a password. I changed the logic, so the input only becomes readonly, if the `login_hint`-query parameter is present. This makes a little more sense semantically as well: If we direct someone to login as a specific user by explicitly providing `login_hint`, we probably don't want them to login as someone else.

## Approval for review

- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
