### PR TITLE
SPSH-1195-fix-servicemonitor

### DIFF
--- a/charts/dbildungs-iam-keycloak/values.yaml
+++ b/charts/dbildungs-iam-keycloak/values.yaml
@@ -128,8 +128,7 @@ keycloak:
   serviceMonitor:
     enabled: true
     path: "/metrics"
-    endpoints:
-      - port: 'mgmt'
+    port: 'mgmt'
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
# Description
Currently vlaue is not right and no port is taken. So Keycloak currently checks both ports for metrics, which results in Errors in the monitoring. It should only use the mgmt port. 

<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs

<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.